### PR TITLE
Example scheduler feature

### DIFF
--- a/booktree.py
+++ b/booktree.py
@@ -371,12 +371,13 @@ if __name__ == "__main__":
 
                     run(cfg)
                     print(f'Next run in {humanize.precisedelta(timedelta(seconds=schedule.idle_seconds()))}.')
+                    myx_utilities.printDivider()
 
                     while True:
-                        n = schedule.idle_seconds()
-                        time.sleep(n)
+                        time.sleep(schedule.idle_seconds())
                         schedule.run_pending()
-                        print(f'Next run in {humanize.precisedelta(timedelta(seconds=n))}.')
+                        print(f'Next run in {humanize.precisedelta(timedelta(seconds=schedule.idle_seconds()))}.')
+                        myx_utilities.printDivider()
                 else:
                     print(f'Mode: \'{mode}\' is not a valid mode. Supported modes: run, scheduled. Please check your config file and try again.')
 

--- a/default_config.cfg
+++ b/default_config.cfg
@@ -1,5 +1,7 @@
 {
     "Config": {
+        "mode": "run",
+        "scheduler_period": 1440,
         "metadata": "mam-audible",
         "matchrate": 50,
         "fuzzy_match": "token_sort",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ langcodes==3.4.0
 pathvalidate==3.2.0
 Requests==2.32.3
 thefuzz==0.22.1
+schedule==1.2.2
+humanize==4.10.0


### PR DESCRIPTION
This adds a very basic scheduler feature. It's based on what qbit_manage does, but simpler.

Adds 'mode' and 'scheduler_period' to the config file. Valid modes are 'run' which just runs the script once like normal and 'scheduled' which schedules the script to run based upon the 'scheduler_period' in minutes.

This is more proof-of-concept than fully ready. I think a few other things would need to be considered first:

- All print statements go directly to console. It might make sense to also direct these to a rotating set of log files via logger for the last few scheduled runs or something.
- Should mode be select able via the CLI? I think it might depend on if ebook/audiobook support is split between config files or uses a single merged one