### PR TITLE
Handled &#39; HTML escape character 

### DIFF
--- a/myx_mam.py
+++ b/myx_mam.py
@@ -127,8 +127,10 @@ def getMAMBook(cfg, titleFilename="", authors="", extension=""):
                     series_info = json.loads(b["series_info"])
                     for series in series_info.values():
                         s=list(series)
-                        book.series.append(myx_classes.Series(str(s[0]), s[1]))    
-            if 'lang_code' in b: 
+                        seriesName = str(s[0])
+                        seriesName = seriesName.replace("&#039;", "'")
+                        book.series.append(myx_classes.Series(seriesName, s[1]))
+            if 'lang_code' in b:
                 book.language=myx_utilities.getLanguage((b["lang_code"]))
             if 'my_snatched' in b:
                 book.snatched=bool((b["my_snatched"])) 


### PR DESCRIPTION
This commit attempts to cover when the  \&#39; HTML escape character is being returned from MAM API for series_info.

I tested it on my own collection after identifying a book series with the character, and the new results look correct:
```
Hardlinking files for The Reality Dysfunction
                        from /data/Audiobooks/Peter F. Hamilton - Night's Dawn/01 The Reality Dysfunction/Night's Dawn Book 1 - The Reality Dysfunction.m4b
                          to /data/SortedAudiobooks/Peter F Hamilton/Nights Dawn/Nights Dawn #1 - The Reality Dysfunction

        Creating target directory: /data/SortedAudiobooks/Peter F Hamilton/Nights Dawn/Nights Dawn #1 - The Reality Dysfunction 


```
Feel free to modify the code to fit better in the repo. 