### PR TITLE
Modified searchMAM to only cache MAM responses when there is at least one snatched result that is returned

### DIFF
--- a/myx_mam.py
+++ b/myx_mam.py
@@ -86,7 +86,15 @@ def searchMAM(cfg, titleFilename, authors, extension):
                     results = r.json()
 
                     #cache this result before returning it
-                    myx_utilities.cacheMe(cacheKey, "mam", results, cfg)
+                    if not results["data"] is None and len((results["data"])) > 0:
+                        cacheResults = False
+                        #parent calls filter to snatched for matching, so check that the result has at least one snatched
+                        for book in results["data"]:
+                            if not book['my_snatched'] is None and bool(book['my_snatched']):
+                                cacheResults = True
+
+                        if cacheResults:
+                            myx_utilities.cacheMe(cacheKey, "mam", results, cfg)
 
                     return (results["data"])
             


### PR DESCRIPTION
I've tested this locally and it seemed to work. I used simple print statements and saw it both caching and not caching depending on the response.