### PR TITLE
Add "Preferred Authors" when using Multi-Authors

### DIFF
--- a/myx_classes.py
+++ b/myx_classes.py
@@ -306,7 +306,8 @@ class BookFile:
         in_series = cfg.get("Config/target_path/in_series")
         no_series = cfg.get("Config/target_path/no_series")
         disc_folder = cfg.get("Config/target_path/disc_folder")
-
+        
+        if (book is not None):
             # Get primary author
             if ((book.authors is not None) and (len(book.authors) == 0)):
                 author = "Unknown"


### PR DESCRIPTION
Say for example I had a set of Authors like "James Case, Mark Seifter, Mikhail Rekun, Paizo" or "Wizards of the Coast, James Wyatt, Jeremy Crawford, Ray Winninger, Christopher Perkins, Wesley Schneider, Ben Petrisor, Makenzie De Armas" and I selected my preferred authors to be "Paizo" and "Wizards of the Coast" then I would want out of all those authors for the folder to be named/labeled either "Paizo" if it was in the list or "Wizards of the Coast" if it was in the list.