### PR TITLE
Proxy configuration support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -53,6 +53,7 @@ A copy of default_config.cfg can be found under the /templates folder.  It is re
 | log_path    |         | Where your log files will be saved. If not set, will default to "logs" | /logs (for docker), logs (for local)   |
 | cache_path  |         | Where your log files will be saved. If not set, will default to "logs" | /config   |
 | session     |         | MAM Session ID (can be removed once one has been saved) |    |
+| proxy     |         | http proxy used to connect to MAM hostname:port (eg 127.0.0.1:8888) |    |
 | paths       |         | This is a *list* of folders and files to be processed              |
 | | files               | File patterns to be searched | ["\*\*/\*.m4b", "\*\*/\*.mp3", "\*\*/\*.m4a"]    |
 | | source_path         | Unorganized folder location | /path/to/downloads   |

--- a/booktree.py
+++ b/booktree.py
@@ -11,6 +11,7 @@ import myx_mam
 import myx_args
 import csv
 import httpx
+import requests
 
 #Main Functions
 def buildTreeFromLog(files, logfile, cfg):
@@ -361,8 +362,10 @@ def main(cfg):
         else:
             print(f"Your source and media paths are invalid. Please check and try again!\nSource:{path}\nMedia:{mediaPath}")
 
-if __name__ == "__main__":
-    
+
+# Entry point for pip install -e .
+def cli_main():
+    """CLI entry point for the booktree command"""
     if not sys.version_info > (3, 10):
         print ("booktree requires python 3.10 or higher. Please upgrade your version")
     else:
@@ -377,6 +380,14 @@ if __name__ == "__main__":
 
             except Exception as e:
                 raise Exception(f"\nThere was a problem reading your config file {myx_args.params.config_file}: {e}\n")
+            
+            proxy = cfg.get("Config/proxy")
+            if proxy:
+                s = requests.Session()
+                proxies = {'http': proxy, 'https': proxy}
+                s.proxies.update(proxies)
+                ipinfo = s.get('https://ipwho.is/').json()
+                print(f"Proxy Configured:\nIP: {ipinfo['ip']} country: {ipinfo['country']}")
             
             #check metadata source
             metadata = cfg.get("Config/metadata")
@@ -394,22 +405,5 @@ if __name__ == "__main__":
         else:
             print(f"\nYour config path is invalid. Please check and try again!\n\tConfig file path:{myx_args.params.config_file}\n")
 
-
-
-
-
-
-        
-
-
-
-
-
-
-        
-        
-
-
- 
-
-
+if __name__ == "__main__":
+    cli_main()

--- a/myx_mam.py
+++ b/myx_mam.py
@@ -12,6 +12,7 @@ def searchMAM(cfg, titleFilename, authors, extension):
     #Config
     session = cfg.get("Config/session")
     log_path = cfg.get("Config/log_path")
+    proxy = cfg.get("Config/proxy")
     ebook = bool(cfg.get("Config/flags/ebooks"))
     audiobook = not (ebook)
     
@@ -36,6 +37,11 @@ def searchMAM(cfg, titleFilename, authors, extension):
         #save cookie for future use
         cookies_filepath = os.path.join(log_path, 'cookies.pkl')
         sess = requests.Session()
+
+        #set proxy if provided
+        if proxy:
+            proxies = {'http': proxy, 'https': proxy}
+            sess.proxies.update(proxies)
 
         #a cookie file exists, use that
         if os.path.exists(cookies_filepath):
@@ -149,12 +155,17 @@ def getMAMBook(cfg, titleFilename="", authors="", extension=""):
 
     return books
 
-def testSessionCookie(mySession):
+def testSessionCookie(mySession, proxy=None):
     isSessionCookieValid = False
 
     #test session and cookie
     #print (f"Cookie: {mySession}")
     try:
+        #set proxy if provided
+        if proxy:
+            proxies = {'http': proxy, 'https': proxy}
+            mySession.proxies.update(proxies)
+
         #Hit cookieCheck API, https://www.myanonamouse.net/json/checkCookie.php
         r = mySession.get('https://www.myanonamouse.net/json/checkCookie.php', timeout=5)  # test cookie    
 
@@ -173,11 +184,17 @@ def checkMAMCookie(cfg):
     #Config
     session = cfg.get("Config/session")
     log_path = cfg.get("Config/log_path")
+    proxy = cfg.get("Config/proxy")
 
     isCookieValid = False
     useConfigSession = False
     cookies_filepath = os.path.join(log_path, 'cookies.pkl')
     sess = requests.Session()
+
+    #set proxy if provided
+    if proxy:
+        proxies = {'http': proxy, 'https': proxy}
+        sess.proxies.update(proxies)
 
     #Check if a cookie file exists
     if os.path.exists(cookies_filepath):
@@ -185,7 +202,7 @@ def checkMAMCookie(cfg):
         #If it does, create a session, using this cookie
         cookies = pickle.load(open(cookies_filepath, 'rb'))
         sess.cookies = cookies
-        isCookieValid = testSessionCookie (sess)
+        isCookieValid = testSessionCookie (sess, proxy)
 
         #if the session cookie is NOT Valid
         if (not isCookieValid):
@@ -202,7 +219,7 @@ def checkMAMCookie(cfg):
     if (useConfigSession):
         if (session is not None) and len(session):
             sess.headers.update({"cookie": f"mam_id={session}"})
-            isCookieValid = testSessionCookie (sess)
+            isCookieValid = testSessionCookie (sess, proxy)
 
         else:
             print (f"No session ID found in the config... Please go to MAM Preferences > Security to create a new session")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "booktree"
+version = "2.2.0"
+description = "Reorganize your audiobooks using ID3 or Audible metadata into a tree structure."
+requires-python = ">=3.10"
+
+dependencies = [
+    "httpx==0.27.0",
+    "langcodes==3.4.0",
+    "pathvalidate==3.2.0",
+    "Requests==2.32.3",
+    "thefuzz==0.22.1",
+]
+
+[project.scripts]
+booktree = "booktree:cli_main"
+
+[tool.setuptools]
+py-modules = [
+    "booktree",
+    "myx_args",
+    "myx_audible",
+    "myx_classes",
+    "myx_mam",
+    "myx_torrent",
+    "myx_utilities",
+]


### PR DESCRIPTION
## Description
Enables the use of a proxy connection for MAM requests, allowing users to route connections through a proxy server such as gluetun's HTTP proxy endpoint.

## Changes
- Added proxy configuration support to MAM module
- Proxy settings can be configured via the config file see [CONFIG.md](https://github.com/myxdvz/booktree/compare/main...geg2048:booktree:main?expand=1#diff-9a8f890c7271a9e9bdabd6026ecd9f8aa10fe23a6f9edd7cc09a24bf73eb0725)
- pip install now possible to use due to the addition of [pyproject.toml](https://github.com/myxdvz/booktree/compare/main...geg2048:booktree:main?expand=1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)
- this allows the usage of booktree as a shell command


## Installation
The package can be installed and updated via pip:
```bash
pip install git+https://github.com/myxdvz/booktree